### PR TITLE
Remove secrets from template

### DIFF
--- a/template/.github/workflows/build.yml
+++ b/template/.github/workflows/build.yml
@@ -9,4 +9,3 @@ on:
 jobs:
   build:
     uses: jbanghub/.github/.github/workflows/shared-build.yml@main
-    secrets: inherit


### PR DESCRIPTION
Reasing can be found [here](https://github.com/apple/pkl/pull/655#discussion_r1788116190), but to repeat it:

> BTW, this has no effect as you can share only secrets in reusable workflows within the same org or between org in the same enterprise. 
>
> Beside if that it looks also pretty dangerous 
>
> See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit 