### PR TITLE
Update GraalPy catalog ref

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -57,7 +57,7 @@
     },
     "oracle/graalpython": {
       "description": "A Python 3 implementation built on GraalVM",
-      "catalog-ref": "https://github.com/oracle/graalpython/blob/HEAD/jbang-catalog.json"
+      "catalog-ref": "https://github.com/oracle/graalpy-extensions/blob/HEAD/jbang-catalog.json"
     }
   },
   "aliases": {},


### PR DESCRIPTION
Some GraalPy projects including JBang support have been moved to a dedicated repository: https://github.com/oracle/graalpy-extensions